### PR TITLE
Add `rdf:type` information to Member and fix ReadableStream types

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -10,7 +10,6 @@ import { Quad_Object, Term } from "@rdfjs/types";
 import {
   enhanced_fetch,
   extractMainNodeShape,
-  FetchConfig,
   getObjects,
   ModulatorFactory,
   Notifier,
@@ -23,6 +22,7 @@ import { OrderedStrategy, StrategyEvents, UnorderedStrategy } from "./strategy";
 import debug from "debug";
 import type { Writer } from "@ajuvercr/js-runner";
 
+import { ReadableStream } from "stream/web";
 export { intoConfig } from "./config";
 export { retry_fetch, extractMainNodeShape } from "./utils";
 export type { Member, Page, Relation } from "./page";
@@ -359,7 +359,7 @@ export class Client {
 
   stream(strategy?: {
     highWaterMark?: number;
-    size?: (chunk: Member) => number;
+    size?: (chunk: Member | undefined) => number;
   }): ReadableStream<Member> {
     const emitted = longPromise();
     const config: UnderlyingDefaultSource = {

--- a/lib/page.ts
+++ b/lib/page.ts
@@ -72,11 +72,7 @@ export function extractRelations(
 
   for (let relationId of relationIds) {
     const node = getObjects(store, relationId, TREE.terms.node, null)[0];
-    const ty = getObjects(store, relationId, RDF.terms.type, null)[0];
-    if (!ty) {
-      console.error(`No type for relation id ${relationId.value}`);
-      continue;
-    }
+    const ty = getObjects(store, relationId, RDF.terms.type, null)[0] || TREE.Relation;
     const path = getObjects(store, relationId, TREE.terms.path, null)[0];
     const value = getObjects(store, relationId, TREE.terms.value, null);
 

--- a/lib/page.ts
+++ b/lib/page.ts
@@ -3,13 +3,14 @@ import { RDF, TREE } from "@treecg/types";
 import { CBDShapeExtractor } from "extract-cbd-shape";
 import { State } from "./state";
 import { RdfStore } from "rdf-stores";
-import { getObjects } from "./utils";
+import { getObjects, memberFromQuads } from "./utils";
 
 export interface Member {
   id: Term;
   quads: Quad[];
   timestamp?: string | Date;
   isVersionOf?: string;
+  type?: Term;
 }
 
 export interface Relation {
@@ -36,27 +37,10 @@ export function extractMembers(
   isVersionOfPath?: Term,
 ): Promise<void>[] {
   const members = getObjects(store, stream, TREE.terms.member, null);
-
-  const extractMember = async (member: Term) => {
-    state.add(member.value);
+  async function extractMember(member: Term) {
     const quads = await extractor.extract(store, member, shapeId);
-    // Get timestamp
-    let timestamp: string | undefined;
-    if (timestampPath) {
-      timestamp = quads.find(
-        (x) => x.subject.equals(member) && x.predicate.equals(timestampPath),
-      )?.object.value;
-    }
-
-    let isVersionOf: string | undefined;
-    if (isVersionOfPath) {
-      isVersionOf = quads.find(
-        (x) => x.subject.equals(member) && x.predicate.equals(isVersionOfPath),
-      )?.object.value;
-    }
-    // Get isVersionof
-    cb({ quads, id: member, isVersionOf, timestamp });
-  };
+    cb(memberFromQuads(member, quads, timestampPath, isVersionOfPath));
+  }
 
   const out: Promise<void>[] = [];
   for (let member of members) {
@@ -88,7 +72,11 @@ export function extractRelations(
 
   for (let relationId of relationIds) {
     const node = getObjects(store, relationId, TREE.terms.node, null)[0];
-    const ty = getObjects(store, relationId, RDF.terms.type, null);
+    const ty = getObjects(store, relationId, RDF.terms.type, null)[0];
+    if (!ty) {
+      console.error(`No type for relation id ${relationId.value}`);
+      continue;
+    }
     const path = getObjects(store, relationId, TREE.terms.path, null)[0];
     const value = getObjects(store, relationId, TREE.terms.value, null);
 
@@ -97,12 +85,19 @@ export function extractRelations(
       const assessableRelations = [];
 
       if (after) {
-        assessableRelations.push(...[TREE.LessThanRelation, TREE.LessThanOrEqualToRelation]);
+        assessableRelations.push(
+          ...[TREE.LessThanRelation, TREE.LessThanOrEqualToRelation]
+        );
         if (before) {
-          assessableRelations.push(...[TREE.GreaterThanRelation, TREE.GreaterThanOrEqualToRelation]);
+          assessableRelations.push(
+            ...[TREE.GreaterThanRelation, TREE.GreaterThanOrEqualToRelation]
+          );
           // This filter applies for all cardinal relations
-          if (assessableRelations.includes(ty[0].value)) {
-            if (ty[0].value === TREE.LessThanRelation && after >= new Date(value[0].value)) {
+          if (assessableRelations.includes(ty.value)) {
+            if (
+              ty.value === TREE.LessThanRelation &&
+              after >= new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -110,7 +105,10 @@ export function extractRelations(
               }
               continue;
             }
-            if (ty[0].value === TREE.LessThanOrEqualToRelation && after > new Date(value[0].value)) {
+            if (
+              ty.value === TREE.LessThanOrEqualToRelation &&
+              after > new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -118,7 +116,10 @@ export function extractRelations(
               }
               continue;
             }
-            if (ty[0].value === TREE.GreaterThanRelation && before <= new Date(value[0].value)) {
+            if (
+              ty.value === TREE.GreaterThanRelation &&
+              before <= new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -126,7 +127,10 @@ export function extractRelations(
               }
               continue;
             }
-            if (ty[0].value === TREE.GreaterThanOrEqualToRelation && before < new Date(value[0].value)) {
+            if (
+              ty.value === TREE.GreaterThanOrEqualToRelation &&
+              before < new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -137,8 +141,11 @@ export function extractRelations(
           }
         } else {
           // This filter only applies for tree:LessThanRelation and tree:LessThanOrEqualToRelation
-          if (assessableRelations.includes(ty[0].value)) {
-            if (ty[0].value === TREE.LessThanRelation && after >= new Date(value[0].value)) {
+          if (assessableRelations.includes(ty.value)) {
+            if (
+              ty.value === TREE.LessThanRelation &&
+              after >= new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -146,7 +153,10 @@ export function extractRelations(
               }
               continue;
             }
-            if (ty[0].value === TREE.LessThanOrEqualToRelation && after > new Date(value[0].value)) {
+            if (
+              ty.value === TREE.LessThanOrEqualToRelation &&
+              after > new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -158,10 +168,15 @@ export function extractRelations(
         }
       } else {
         if (before) {
-          assessableRelations.push(...[TREE.GreaterThanRelation, TREE.GreaterThanOrEqualToRelation]);
+          assessableRelations.push(
+            ...[TREE.GreaterThanRelation, TREE.GreaterThanOrEqualToRelation]
+          );
           // This filter only applies for tree:GreaterThanRelation and tree:GreaterThanOrEqualToRelation
-          if (assessableRelations.includes(ty[0].value)) {
-            if (ty[0].value === TREE.GreaterThanRelation && before <= new Date(value[0].value)) {
+          if (assessableRelations.includes(ty.value)) {
+            if (
+              ty.value === TREE.GreaterThanRelation &&
+              before <= new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -169,7 +184,10 @@ export function extractRelations(
               }
               continue;
             }
-            if (ty[0].value === TREE.GreaterThanOrEqualToRelation && before < new Date(value[0].value)) {
+            if (
+              ty.value === TREE.GreaterThanOrEqualToRelation &&
+              before < new Date(value[0].value)
+            ) {
               filteredNodes.add(node.value);
               if (allowedNodes.has(node.value)) {
                 // In case a permissive relation had allowed this node before
@@ -178,7 +196,9 @@ export function extractRelations(
               continue;
             }
           }
-        } else { /* No filters, everything is allowed */ }
+        } else {
+          /* No filters, everything is allowed */
+        }
       }
     }
 
@@ -186,7 +206,7 @@ export function extractRelations(
       allowedNodes.set(node.value, {
         source,
         node: node.value,
-        type: ty[0],
+        type: ty,
         path,
         value,
       });

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -2,6 +2,7 @@ import { Quad } from "@rdfjs/types";
 import { Parser, Writer } from "n3";
 import { Member } from "../lib/page";
 import { TREE } from "@treecg/types";
+import { ReadableStream } from "stream/web";
 
 export type FragmentId = number;
 


### PR DESCRIPTION
This pull request contains the changes that I had to make to be able to implement LDES synchronisation with TriplyDB.

# `ReadableStream`
I wanted to use `for await (const member of client.stream(...)) { ... }` syntax ([nodejs documentation](https://nodejs.org/docs/latest-v20.x/api/webstreams.html#async-iteration)).

# `memberFromQuads`
- We need information about the `rdf:type` of a member to find out whether the mentioned `isVersionOf` should be removed or upserted.
- I first changed the code in the wrong place, so I wrote a reusable `memberFromQuads` function

# `No type for relation id ${relationId.value}`
The LDES endpoint that I was developing against had one member without a type, so I had to check this to prevent the `Client` from crashing.