### PR TITLE
tree:InBetweenRelation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ ldes-client <url> [-f] [--save <path>] [--pollInterval <number>] [--shape <shape
 - `-s` `--state`: filepath to the save state file to use, used both to resume and to update
 - `--pollInterval`: time to wait between polling the LDES when the client is following the LDES.
 - `--shape`: shape file to which LDES members should conform (overwrite LDES configured shape)
-- Others soon comming
+- `-t` `--default-timezone`: default timezone to use for dates in tree:InBetweenRelation. `AoE|Z|±HH:mm` Default: `AoE`.
+- Others soon coming
 
 
 You can also use this as a library in your TS/JS projects. See the [client.ts](lib/client.ts) file for documentation.

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -24,6 +24,7 @@ let quiet: boolean = false;
 let save: string | undefined;
 let onlyDefaultGraph: boolean = false;
 let loose: boolean = false;
+let defaultTimezone: string | undefined;
 
 let fetch_config: FetchConfig = {
     retry: {},
@@ -84,6 +85,7 @@ program
         "3",
     )
     .option("--http-codes [codes...]", "What HTTP codes to retry")
+    .option("-t --default-timezone <timezone>", "Default timezone for dates in tree:InBetweenRelation", "AoE")
     .action((url: string, program) => {
         urlIsView = program.urlIsView;
         noShape = !program.shape;
@@ -97,6 +99,7 @@ program
         loose = program.loose;
         onlyDefaultGraph = program.onlyDefaultGraph;
         conditionFile = program.condition;
+        defaultTimezone = program.defaultTimezone;
 
         fetch_config.concurrent = parseInt(program.concurrent);
         if (program.basicAuth) {
@@ -159,6 +162,7 @@ async function main() {
             shapeFile,
             onlyDefaultGraph,
             condition,
+            defaultTimezone,
             fetch: enhanced_fetch(fetch_config),
         }),
         ordered,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -285,6 +285,7 @@ export class Client {
       this.dereferencer,
       this.config.loose,
       this.config.condition,
+      this.config.defaultTimezone,
       this.config.fetch,
     );
 

--- a/lib/condition/condition.ts
+++ b/lib/condition/condition.ts
@@ -3,315 +3,569 @@ import { NamedNode, Parser } from "n3";
 import { BasicLensM, Cont, extractShapes } from "rdf-lens";
 import { RdfStore } from "rdf-stores";
 import { Member } from "../page";
-import { TREE } from "@treecg/types";
+import { TREE, XSD } from "@treecg/types";
 import { SHAPES } from "./shapes";
 import { cbdEquals, Path } from "./range";
 import { getLoggerFor } from "../utils/logUtil";
 
 type RdfThing = {
-  entry: Term;
-  quads: Quad[];
+    entry: Term;
+    quads: Quad[];
 };
 
 export interface Condition {
-  matchRelation(
-    range: Range | undefined,
-    cbdId: Path,
-  ): boolean;
+    matchRelation(
+        range: Range | undefined,
+        cbdId: Path,
+    ): boolean;
 
-  matchMember(member: Member): boolean;
+    matchMember(member: Member): boolean;
 
-  toString(): string;
+    toString(): string;
 }
 
 export function empty_condition(): Condition {
-  return new EmptyCondition();
+    return new EmptyCondition();
 }
 
 export function parse_condition(source: string, baseIRI: string): Condition {
-  const shapeQuads = new Parser().parse(SHAPES);
-  const output = extractShapes(shapeQuads, {
-    "https://w3id.org/tree#And": (obj) =>
-      new AndCondition(<ConstructorParameters<typeof AndCondition>[0]>obj),
-    "https://w3id.org/tree#Or": (obj) =>
-      new OrCondition(<ConstructorParameters<typeof OrCondition>[0]>obj),
-    "https://w3id.org/tree#Condition": (obj) =>
-      new LeafCondition(<ConstructorParameters<typeof LeafCondition>[0]>obj),
-  });
+    const shapeQuads = new Parser().parse(SHAPES);
+    const output = extractShapes(shapeQuads, {
+        "https://w3id.org/tree#And": (obj) =>
+            new AndCondition(<ConstructorParameters<typeof AndCondition>[0]>obj),
+        "https://w3id.org/tree#Or": (obj) =>
+            new OrCondition(<ConstructorParameters<typeof OrCondition>[0]>obj),
+        "https://w3id.org/tree#Condition": (obj) =>
+            new LeafCondition(<ConstructorParameters<typeof LeafCondition>[0]>obj),
+    });
 
-  const dataQuads = new Parser({ baseIRI: baseIRI }).parse(source);
+    const dataQuads = new Parser({ baseIRI: baseIRI }).parse(source);
 
-  return <Condition> output.lenses[
-    "https://w3id.org/rdf-lens/ontology#TypedExtract"
-  ].execute({
-    quads: dataQuads,
-    id: new NamedNode(baseIRI),
-  });
+    return <Condition>output.lenses[
+        "https://w3id.org/rdf-lens/ontology#TypedExtract"
+        ].execute({
+        quads: dataQuads,
+        id: new NamedNode(baseIRI),
+    });
 }
 
 type CompareTypes = "string" | "date" | "integer" | "float";
 
 export class Range {
-  min?: any;
-  eqMin: boolean = true;
+    min?: any;
+    eqMin: boolean = true;
 
-  max?: any;
-  eqMax: boolean = true;
+    max?: any;
+    eqMax: boolean = true;
 
-  constructor(value: any, type: string) {
-    switch (type) {
-      case TREE.EqualToRelation:
-        this.min = value;
-        this.max = value;
-        return;
-      case TREE.LessThanRelation:
-        this.max = value;
-        this.eqMax = false;
-        return;
-      case TREE.LessThanOrEqualToRelation:
-        this.max = value;
-        return;
-      case TREE.GreaterThanRelation:
-        this.min = value;
-        this.eqMin = false;
-        return;
-      case TREE.GreaterThanOrEqualToRelation:
-        this.min = value;
-        return;
-    }
-  }
+    private logger = getLoggerFor(this);
 
-  static empty(): Range {
-    return new Range(null, TREE.Relation);
-  }
+    private defaultTimezone: string;
 
-  add(value: any, type: string) {
-    switch (type) {
-      case TREE.EqualToRelation:
-        this.min = value;
-        this.max = value;
-        return;
-      case TREE.LessThanRelation:
-        if (!this.max || value < this.max) {
-          this.max = value;
-          this.eqMax = false;
+    constructor(value: any, type: string, defaultTimezone: string, dataType?: string) {
+        const tzRegex = /^(AoE|Z|[+-]((0[0-9]|1[0-3]):([0-5][0-9])|14:00))$/;
+        if (!tzRegex.test(defaultTimezone)) {
+            this.logger.warn(`Invalid timezone: '${defaultTimezone}'. Using default Anywhere on Earth (AoE) instead.`);
+            this.defaultTimezone = "AoE";
+        } else {
+            this.defaultTimezone = defaultTimezone;
         }
-        return;
-      case TREE.LessThanOrEqualToRelation:
-        if (!this.max || value < this.max) {
-          this.max = value;
+        switch (type) {
+            case TREE.EqualToRelation:
+                this.min = value;
+                this.max = value;
+                return;
+            case TREE.LessThanRelation:
+                this.max = value;
+                this.eqMax = false;
+                return;
+            case TREE.LessThanOrEqualToRelation:
+                this.max = value;
+                return;
+            case TREE.GreaterThanRelation:
+                this.min = value;
+                this.eqMin = false;
+                return;
+            case TREE.GreaterThanOrEqualToRelation:
+                this.min = value;
+                return;
+            case TREE.custom("InBetweenRelation"):
+                if (dataType === XSD.custom("gYear")) {
+                    const result = this.gYearToMinMax(value);
+                    if (!result) return;
+                    [this.min, this.max] = result;
+                    this.eqMin = true;
+                    this.eqMax = false;
+                } else if (dataType === XSD.custom("gYearMonth")) {
+                    const result = this.gYearMonthToMinMax(value);
+                    if (!result) return;
+                    [this.min, this.max] = result;
+                    this.eqMin = true;
+                    this.eqMax = false;
+                } else if (dataType === XSD.custom("date")) {
+                    const result = this.dateToMinMax(value);
+                    if (!result) return;
+                    [this.min, this.max] = result;
+                    this.eqMin = true;
+                    this.eqMax = false;
+                } else {
+                    // Check if it is a partial dateTime.
+                    const result = this.partialDateTimeToMinMax(value);
+                    if (!result) return;
+                    [this.min, this.max] = result;
+                    this.eqMin = true;
+                    this.eqMax = false;
+                }
+                return;
         }
-        return;
-      case TREE.GreaterThanRelation:
-        if (!this.min || value > this.min) {
-          this.min = value;
-          this.eqMin = false;
+    }
+
+    static empty(defaultTimezone: string): Range {
+        return new Range(null, TREE.Relation, defaultTimezone);
+    }
+
+    add(value: any, type: string, dataType?: string) {
+        switch (type) {
+            case TREE.EqualToRelation:
+                this.min = value;
+                this.max = value;
+                return;
+            case TREE.LessThanRelation:
+                if (!this.max || value < this.max) {
+                    this.max = value;
+                    this.eqMax = false;
+                }
+                return;
+            case TREE.LessThanOrEqualToRelation:
+                if (!this.max || value < this.max) {
+                    this.max = value;
+                }
+                return;
+            case TREE.GreaterThanRelation:
+                if (!this.min || value > this.min) {
+                    this.min = value;
+                    this.eqMin = false;
+                }
+                return;
+            case TREE.GreaterThanOrEqualToRelation:
+                if (!this.min || value > this.min) {
+                    this.min = value;
+                }
+                return;
+            case TREE.custom("InBetweenRelation"):
+                if (dataType === XSD.custom("gYear")) {
+                    const result = this.gYearToMinMax(value);
+                    if (!result) return;
+                    const [min, max] = result;
+                    if (!this.min || min <= this.min) {
+                        this.min = min;
+                        this.eqMin = true;
+                    }
+                    if (!this.max || max > this.max) {
+                        this.max = max;
+                        this.eqMax = false;
+                    }
+                } else if (dataType === XSD.custom("gYearMonth")) {
+                    const result = this.gYearMonthToMinMax(value);
+                    if (!result) return;
+                    const [min, max] = result;
+                    if (!this.min || min <= this.min) {
+                        this.min = min;
+                        this.eqMin = true;
+                    }
+                    if (!this.max || max > this.max) {
+                        this.max = max;
+                        this.eqMax = false;
+                    }
+                } else if (dataType === XSD.custom("date")) {
+                    const result = this.dateToMinMax(value);
+                    if (!result) return;
+                    const [min, max] = result;
+                    if (!this.min || min <= this.min) {
+                        this.min = min;
+                        this.eqMin = true;
+                    }
+                    if (!this.max || max > this.max) {
+                        this.max = max;
+                        this.eqMax = false;
+                    }
+                } else {
+                    // Check if it is a partial dateTime
+                    const result = this.partialDateTimeToMinMax(value);
+                    if (!result) return;
+                    const [min, max] = result;
+                    if (!this.min || min <= this.min) {
+                        this.min = min;
+                        this.eqMin = true;
+                    }
+                    if (!this.max || max > this.max) {
+                        this.max = max;
+                        this.eqMax = false;
+                    }
+                }
+                return;
         }
-        return;
-      case TREE.GreaterThanOrEqualToRelation:
-        if (!this.min || value > this.min) {
-          this.min = value;
+    }
+
+    contains(value: any): boolean {
+        if (this.min) {
+            if (this.eqMin) {
+                if (this.min > value) return false;
+            } else {
+                if (this.min >= value) return false;
+            }
         }
-        return;
-    }
-  }
-
-  contains(value: any): boolean {
-    if (this.min) {
-      if (this.eqMin) {
-        if (this.min > value) return false;
-      } else {
-        if (this.min >= value) return false;
-      }
-    }
-    if (this.max) {
-      if (this.eqMax) {
-        if (this.max < value) return false;
-      } else {
-        if (this.max <= value) return false;
-      }
-    }
-    return true;
-  }
-
-  overlaps(other: Range): boolean {
-    if (this.min && other.max) {
-      if (this.eqMin && other.eqMax) {
-        if (this.min > other.max) return false;
-      } else {
-        if (this.min >= other.max) return false;
-      }
+        if (this.max) {
+            if (this.eqMax) {
+                if (this.max < value) return false;
+            } else {
+                if (this.max <= value) return false;
+            }
+        }
+        return true;
     }
 
-    if (this.max && other.min) {
-      if (this.eqMax && other.eqMin) {
-        if (other.min > this.max) return false;
-      } else {
-        if (other.min >= this.max) return false;
-      }
+    overlaps(other: Range): boolean {
+        if (this.min && other.max) {
+            if (this.eqMin && other.eqMax) {
+                if (this.min > other.max) return false;
+            } else {
+                if (this.min >= other.max) return false;
+            }
+        }
+
+        if (this.max && other.min) {
+            if (this.eqMax && other.eqMin) {
+                if (other.min > this.max) return false;
+            } else {
+                if (other.min >= this.max) return false;
+            }
+        }
+
+        return true;
     }
 
-    return true;
-  }
+    toString(valueToString?: (value: any) => string): string {
+        const vts = valueToString || ((x: any) => x.toString());
+        const comma = !!this.min && !!this.max ? "," : "";
+        const start = this.min ? (this.eqMin ? "[" : "(") + vts(this.min) : "]";
+        const end = this.max ? vts(this.max) + (this.eqMax ? "]" : ")") : "[";
+        return start + comma + end;
+    }
 
-  toString(valueToString?: (value: any) => string): string {
-    const vts = valueToString || ((x: any) => x.toString());
-    const comma = !!this.min && !!this.max ? "," : "";
-    const start = this.min ? (this.eqMin ? "[" : "(") + vts(this.min) : "]";
-    const end = this.max ? vts(this.max) + (this.eqMax ? "]" : ")") : "[";
-    return start + comma + end;
-  }
+    private gYearToMinMax(value: string): [Date, Date] | undefined {
+        const regex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const match = value.match(regex);
+        if (!match) {
+            this.logger.warn(`Invalid gYear format: ${value}`);
+            return;
+        }
+        const year = parseInt(match[1]);
+        let minOffset = 0;
+        let maxOffset = 0;
+        const timezone = match[2] || this.defaultTimezone;
+        if (timezone === "AoE") {
+            // Anywhere on Earth approach.
+            minOffset = -12 * 60;
+            maxOffset = 12 * 60;
+        } else if (timezone !== "Z") {
+            const sign = match[3];
+            const h = parseInt(match[5]);
+            const m = parseInt(match[6]);
+            const offset = (sign === "+" ? 1 : -1) * (h * 60 + m);
+            minOffset = offset;
+            maxOffset = offset;
+        }
+        return [new Date(Date.UTC(year, 0, 1) + minOffset * 60 * 1000), new Date(Date.UTC(year + 1, 0, 1) + maxOffset * 60 * 1000)];
+    }
+
+    private gYearMonthToMinMax(value: string): [Date, Date] | undefined {
+        const regex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})-(0[1-9]|1[0-2])(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const match = value.match(regex);
+        if (!match) {
+            this.logger.warn(`Invalid gYearMonth format: ${value}`);
+            return;
+        }
+        const y = parseInt(match[1]);
+        const m = parseInt(match[2]);
+        let minOffset = 0;
+        let maxOffset = 0;
+        const timezone = match[3] || this.defaultTimezone;
+        if (timezone === "AoE") {
+            // Anywhere on Earth approach.
+            minOffset = -12 * 60;
+            maxOffset = 12 * 60;
+        } else if (timezone !== "Z") {
+            const sign = match[4];
+            const h = parseInt(match[6]);
+            const min = parseInt(match[7]);
+            const offset = (sign === "+" ? 1 : -1) * (h * 60 + min);
+            minOffset = offset;
+            maxOffset = offset;
+        }
+        return [new Date(Date.UTC(y, m - 1, 1) + minOffset * 60 * 1000), new Date(Date.UTC(y, m, 1) + maxOffset * 60 * 1000)];
+    }
+
+    private dateToMinMax(value: string): [Date, Date] | undefined {
+        const regex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const match = value.match(regex);
+        if (!match) {
+            this.logger.warn(`Invalid date format: ${value}`);
+            return;
+        }
+        const y = parseInt(match[1]);
+        const m = parseInt(match[2]);
+        const d = parseInt(match[3]);
+        let minOffset = 0;
+        let maxOffset = 0;
+        const timezone = match[4] || this.defaultTimezone;
+        if (timezone === "AoE") {
+            // Anywhere on Earth approach.
+            minOffset = -12 * 60;
+            maxOffset = 12 * 60;
+        } else if (timezone !== "Z") {
+            const sign = match[5];
+            const h = parseInt(match[7]);
+            const min = parseInt(match[8]);
+            const offset = (sign === "+" ? 1 : -1) * (h * 60 + min);
+            minOffset = offset;
+            maxOffset = offset;
+        }
+        return [new Date(Date.UTC(y, m - 1, d) + minOffset * 60 * 1000), new Date(Date.UTC(y, m - 1, d + 1) + maxOffset * 60 * 1000)];
+    }
+
+    private partialDateTimeToMinMax(value: string): [Date, Date] | undefined {
+        const dateHourMinSecRegex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const matchDHMS = value.match(dateHourMinSecRegex);
+        if (matchDHMS) {
+            const y = parseInt(matchDHMS[1]);
+            const m = parseInt(matchDHMS[2]);
+            const d = parseInt(matchDHMS[3]);
+            const h = parseInt(matchDHMS[4]);
+            const min = parseInt(matchDHMS[5]);
+            const s = parseInt(matchDHMS[6]);
+            let minOffset = 0;
+            let maxOffset = 0;
+            const timezone = matchDHMS[7] || this.defaultTimezone;
+            if (timezone === "AoE") {
+                // Anywhere on Earth approach.
+                minOffset = -12 * 60;
+                maxOffset = 12 * 60;
+            } else if (timezone !== "Z") {
+                const sign = matchDHMS[8];
+                const hOff = parseInt(matchDHMS[10]);
+                const minOff = parseInt(matchDHMS[11]);
+                const offset = (sign === "+" ? 1 : -1) * (hOff * 60 + minOff);
+                minOffset = offset;
+                maxOffset = offset;
+            }
+            return [new Date(Date.UTC(y, m - 1, d, h, min, s) + minOffset * 60 * 1000), new Date(Date.UTC(y, m - 1, d, h, min, s + 1) + maxOffset * 60 * 1000)];
+        }
+        const dateHourMinRegex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9])(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const matchDHM = value.match(dateHourMinRegex);
+        if (matchDHM) {
+            const y = parseInt(matchDHM[1]);
+            const m = parseInt(matchDHM[2]);
+            const d = parseInt(matchDHM[3]);
+            const h = parseInt(matchDHM[4]);
+            const min = parseInt(matchDHM[5]);
+            let minOffset = 0;
+            let maxOffset = 0;
+            const timezone = matchDHM[6] || this.defaultTimezone;
+            if (timezone === "AoE") {
+                // Anywhere on Earth approach.
+                minOffset = -12 * 60;
+                maxOffset = 12 * 60;
+            } else if (timezone !== "Z") {
+                const sign = matchDHM[7];
+                const hOff = parseInt(matchDHM[9]);
+                const minOff = parseInt(matchDHM[10]);
+                const offset = (sign === "+" ? 1 : -1) * (hOff * 60 + minOff);
+                minOffset = offset;
+                maxOffset = offset;
+            }
+            return [new Date(Date.UTC(y, m - 1, d, h, min) + minOffset * 60 * 1000), new Date(Date.UTC(y, m - 1, d, h, min + 1) + maxOffset * 60 * 1000)];
+        }
+        const dateHourRegex = /^(-?[1-9][0-9]{3,}|-?0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3])(Z|(\+|-)((0[0-9]|1[0-3]):([0-5][0-9])|14:00))?$/;
+        const matchDH = value.match(dateHourRegex);
+        if (matchDH) {
+            const y = parseInt(matchDH[1]);
+            const m = parseInt(matchDH[2]);
+            const d = parseInt(matchDH[3]);
+            const h = parseInt(matchDH[4]);
+            let minOffset = 0;
+            let maxOffset = 0;
+            const timezone = matchDH[5] || this.defaultTimezone;
+            if (timezone === "AoE") {
+                // Anywhere on Earth approach.
+                minOffset = -12 * 60;
+                maxOffset = 12 * 60;
+            } else if (timezone !== "Z") {
+                const sign = matchDH[6];
+                const hOff = parseInt(matchDH[8]);
+                const minOff = parseInt(matchDH[9]);
+                const offset = (sign === "+" ? 1 : -1) * (hOff * 60 + minOff);
+                minOffset = offset;
+                maxOffset = offset;
+            }
+            return [new Date(Date.UTC(y, m - 1, d, h) + minOffset * 60 * 1000), new Date(Date.UTC(y, m - 1, d, h + 1) + maxOffset * 60 * 1000)];
+        }
+    }
 }
 
 export class LeafCondition implements Condition {
-  relationType: Term;
-  value: string;
-  compareType: CompareTypes;
-
-  path: BasicLensM<Cont, Cont>;
-  pathQuads: Path;
-
-  range: Range;
-
-  private logger = getLoggerFor(this);
-
-  constructor(inp: {
     relationType: Term;
     value: string;
-    compareType?: string;
+    compareType: CompareTypes;
+
     path: BasicLensM<Cont, Cont>;
-    pathQuads: RdfThing;
-  }) {
-    this.relationType = inp.relationType;
-    this.value = inp.value;
-    this.compareType = <CompareTypes> inp.compareType || "string";
-    this.path = inp.path;
-    const store = RdfStore.createDefault();
-    inp.pathQuads.quads.forEach((x) => store.addQuad(x));
-    this.pathQuads = { id: inp.pathQuads.entry, store };
+    pathQuads: Path;
 
-    this.range = new Range(this.parseValue(inp.value), inp.relationType.value);
-  }
+    range: Range;
 
-  toString(): string {
-    const vts = this.compareType === "date"
-      ? (x: Date) => x.toISOString()
-      : undefined;
-    return `${this.pathQuads.id.value} ∈ ${this.range.toString(vts)}`;
-  }
+    defaultTimezone: string;
 
-  matchRelation(
-    range: Range | undefined,
-    cbdId: Path,
-  ): boolean {
-    if (!cbdEquals(this.pathQuads, cbdId)) {
-      return true;
-    }
-    if (!range) {
-      this.logger.debug(
-        "[matchRelation] Range is here also undefined, returning false",
-      );
-      return false;
+    private logger = getLoggerFor(this);
+
+    constructor(inp: {
+        relationType: Term;
+        value: string;
+        compareType?: string;
+        path: BasicLensM<Cont, Cont>;
+        pathQuads: RdfThing;
+        defaultTimezone: string;
+    }) {
+        this.relationType = inp.relationType;
+        this.value = inp.value;
+        this.compareType = <CompareTypes>inp.compareType || "string";
+        this.path = inp.path;
+        const store = RdfStore.createDefault();
+        inp.pathQuads.quads.forEach((x) => store.addQuad(x));
+        this.pathQuads = { id: inp.pathQuads.entry, store };
+        this.defaultTimezone = inp.defaultTimezone;
+
+        this.range = new Range(this.parseValue(inp.value), inp.relationType.value, this.defaultTimezone);
     }
 
-    const vts = this.compareType === "date"
-      ? (x: Date) => new Date(x).toISOString()
-      : undefined;
-    this.logger.verbose(
-      `${this.range.toString(vts)} contains ${range.toString(vts)}. Overlaps: ${
-        this.range.overlaps(range)
-      }`,
-    );
-
-    return this.range.overlaps(range);
-  }
-
-  matchMember(member: Member): boolean {
-    const value = this.parseValue(this.path.execute(member)[0].id.value);
-    return this.range.contains(value);
-  }
-
-  private parseValue(value: string): any {
-    switch (this.compareType) {
-      case "string":
-        return value;
-      case "date":
-        return new Date(value);
-      case "integer":
-        return parseInt(value);
-      case "float":
-        return parseFloat(value);
-      default:
-        return value;
+    toString(): string {
+        const vts = this.compareType === "date"
+            ? (x: Date) => x.toISOString()
+            : undefined;
+        return `${this.pathQuads.id.value} ∈ ${this.range.toString(vts)}`;
     }
-  }
+
+    matchRelation(
+        range: Range | undefined,
+        cbdId: Path,
+    ): boolean {
+        if (!cbdEquals(this.pathQuads, cbdId)) {
+            return true;
+        }
+        if (!range) {
+            this.logger.debug(
+                "[matchRelation] Range is here also undefined, returning false",
+            );
+            return false;
+        }
+
+        const vts = this.compareType === "date"
+            ? (x: Date) => new Date(x).toISOString()
+            : undefined;
+        this.logger.verbose(
+            `${this.range.toString(vts)} contains ${range.toString(vts)}. Overlaps: ${
+                this.range.overlaps(range)
+            }`,
+        );
+
+        return this.range.overlaps(range);
+    }
+
+    matchMember(member: Member): boolean {
+        const value = this.parseValue(this.path.execute(member)[0].id.value);
+        return this.range.contains(value);
+    }
+
+    private parseValue(value: string): any {
+        switch (this.compareType) {
+            case "string":
+                return value;
+            case "date":
+                return new Date(value);
+            case "integer":
+                return parseInt(value);
+            case "float":
+                return parseFloat(value);
+            default:
+                return value;
+        }
+    }
 }
 
 abstract class BiCondition implements Condition {
-  alpha: Condition;
-  beta: Condition;
+    alpha: Condition;
+    beta: Condition;
 
-  private logger = getLoggerFor(this);
+    private logger = getLoggerFor(this);
 
-  constructor(inp: { alpha: Condition; beta: Condition }) {
-    this.alpha = inp.alpha;
-    this.beta = inp.beta;
-  }
+    constructor(inp: { alpha: Condition; beta: Condition }) {
+        this.alpha = inp.alpha;
+        this.beta = inp.beta;
+    }
 
-  abstract combine(alpha: boolean, beta: boolean): boolean;
+    abstract combine(alpha: boolean, beta: boolean): boolean;
 
-  matchRelation(
-    range: Range | undefined,
-    cbdId: Path,
-  ): boolean {
-    const alpha = this.alpha.matchRelation(range, cbdId);
-    const beta = this.beta.matchRelation(range, cbdId);
+    matchRelation(
+        range: Range | undefined,
+        cbdId: Path,
+    ): boolean {
+        const alpha = this.alpha.matchRelation(range, cbdId);
+        const beta = this.beta.matchRelation(range, cbdId);
 
-    this.logger.verbose(`> ${this.combine(alpha, beta)}`);
+        this.logger.verbose(`> ${this.combine(alpha, beta)}`);
 
-    return this.combine(alpha, beta);
-  }
+        return this.combine(alpha, beta);
+    }
 
-  matchMember(member: Member): boolean {
-    const alpha = this.alpha.matchMember(member);
-    const beta = this.beta.matchMember(member);
-    return this.combine(alpha, beta);
-  }
+    matchMember(member: Member): boolean {
+        const alpha = this.alpha.matchMember(member);
+        const beta = this.beta.matchMember(member);
+        return this.combine(alpha, beta);
+    }
 }
 
 export class AndCondition extends BiCondition {
-  combine(alpha: boolean, beta: boolean): boolean {
-    return alpha && beta; // TODO those might be null if something cannot make a statement about it, important for not condition
-  }
+    combine(alpha: boolean, beta: boolean): boolean {
+        return alpha && beta; // TODO those might be null if something cannot make a statement about it, important for not condition
+    }
 
-  toString(): string {
-    return `(${this.alpha.toString()} ^ ${this.beta.toString()})`;
-  }
+    toString(): string {
+        return `(${this.alpha.toString()} ^ ${this.beta.toString()})`;
+    }
 }
 
 export class OrCondition extends BiCondition {
-  combine(alpha: boolean, beta: boolean): boolean {
-    return alpha || beta; // TODO those might be null if something cannot make a statement about it, important for not condition
-  }
+    combine(alpha: boolean, beta: boolean): boolean {
+        return alpha || beta; // TODO those might be null if something cannot make a statement about it, important for not condition
+    }
 
-  toString(): string {
-    return `(${this.alpha.toString()} V ${this.beta.toString()})`;
-  }
+    toString(): string {
+        return `(${this.alpha.toString()} V ${this.beta.toString()})`;
+    }
 }
 
 export class EmptyCondition implements Condition {
-  private logger = getLoggerFor(this);
+    private logger = getLoggerFor(this);
 
-  matchRelation(_range: Range, _cbdId: Path): boolean {
-    this.logger.verbose("[matchRelation] Returning true");
-    return true;
-  }
+    matchRelation(_range: Range, _cbdId: Path): boolean {
+        this.logger.verbose("[matchRelation] Returning true");
+        return true;
+    }
 
-  matchMember(_member: Member): boolean {
-    return true;
-  }
+    matchMember(_member: Member): boolean {
+        return true;
+    }
 
-  toString() {
-    return "all";
-  }
+    toString() {
+        return "all";
+    }
 }

--- a/lib/condition/range.ts
+++ b/lib/condition/range.ts
@@ -1,4 +1,4 @@
-import { Quad, Term } from "@rdfjs/types";
+import { Literal, Quad, Term } from "@rdfjs/types";
 import { RdfStore } from "rdf-stores";
 import { getObjects } from "../utils";
 import { RDF, TREE } from "@treecg/types";
@@ -51,12 +51,15 @@ type PathRange = {
 export class RelationCondition {
   store: RdfStore<any, Quad>;
 
+  defaultTimezone: string;
+
   ranges: PathRange[] = [];
 
   private logger = getLoggerFor(this);
 
-  constructor(store: RdfStore<any, Quad>) {
+  constructor(store: RdfStore<any, Quad>, defaultTimezone: string) {
     this.store = store;
+    this.defaultTimezone = defaultTimezone;
   }
 
   allowed(condition: Condition): boolean {
@@ -89,7 +92,7 @@ export class RelationCondition {
     if (!range) {
       const newRange: PathRange = {
         cbdEntry: path,
-        range: Range.empty(),
+        range: Range.empty(this.defaultTimezone),
       };
       this.ranges.push(newRange);
       range = newRange;
@@ -100,6 +103,6 @@ export class RelationCondition {
       return;
     }
 
-    range.range?.add(value.value, ty.value);
+    range.range?.add(value.value, ty.value, (value as Literal)?.datatype?.value);
   }
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,6 +15,7 @@ export interface Config {
   stateFile?: string;
   pollInterval: number;
   condition: Condition;
+  defaultTimezone: string;
   shape?: ShapeConfig;
   shapeFile?: string;
   onlyDefaultGraph?: boolean;
@@ -33,6 +34,7 @@ const defaultConfig: Config = {
   polling: false,
   url: "",
   pollInterval: 200,
+  defaultTimezone: "AoE",
 };
 
 const defaultTarget: WithTarget = {

--- a/lib/page.ts
+++ b/lib/page.ts
@@ -63,6 +63,7 @@ export function extractRelations(
   node: Term,
   loose: boolean,
   condition: Condition,
+  defaultTimezone: string,
 ): Relation[] {
   const logger = getLoggerFor("extractRelations");
 
@@ -95,7 +96,7 @@ export function extractRelations(
         id: relationId,
       };
       conditions.set(node.value, {
-        cond: new RelationCondition(store),
+        cond: new RelationCondition(store, defaultTimezone),
         relation,
       });
     }

--- a/lib/pageFetcher.ts
+++ b/lib/pageFetcher.ts
@@ -66,6 +66,7 @@ export class Fetcher {
     private loose: boolean;
     private fetch_f?: typeof fetch;
     private condition: Condition;
+    private defaultTimezone: string;
 
     private closed = false;
 
@@ -75,12 +76,14 @@ export class Fetcher {
         dereferencer: RdfDereferencer,
         loose: boolean,
         condition: Condition,
+        defaultTimezone: string,
         fetch_f?: typeof fetch,
     ) {
         this.dereferencer = dereferencer;
         this.loose = loose;
         this.fetch_f = fetch_f;
         this.condition = condition;
+        this.defaultTimezone = defaultTimezone;
     }
 
     close() {
@@ -143,6 +146,7 @@ export class Fetcher {
                 namedNode(resp.url),
                 this.loose,
                 this.condition,
+                this.defaultTimezone,
             )) {
                 if (!node.expected.some((x) => x == rel.node)) {
                     if (!this.closed) {


### PR DESCRIPTION
- Adds support for the `tree:InBetweenRelation` relation with partial dateTimes.
- Adds a config parameter `defaultTimezone` to be used with this relation, in case the LDES being consumed does not specify the timezones for the relation's `tree:value`.
  - Options: `AoE` for Anywhere on Earth (will consider ≥ with value -12h & < with value + 12h), `Z` for UTC, `±HH:mm` for any other timezone.
  - Default: `AoE` as this will never let you miss relevant members because of different timezones being used.
  - Allowing to set this timezone allows a client with pre knowledge about the timezone being used in the InBetweenRelations, to achieve a performance gain, as less/no irrelevant fragments will be retrieved.