### PR TITLE
bug: identify and fix bug related to descending ordering using the LD…

### DIFF
--- a/lib/condition/range.ts
+++ b/lib/condition/range.ts
@@ -1,9 +1,8 @@
-import { Literal, Quad, Term } from "@rdfjs/types";
+import { Quad, Term } from "@rdfjs/types";
 import { RdfStore } from "rdf-stores";
 import { getObjects } from "../utils";
 import { RDF, TREE } from "@treecg/types";
 import { Condition, Range } from "./condition";
-import { getLoggerFor } from "../utils/logUtil";
 
 export type Path = {
     store: RdfStore;
@@ -68,9 +67,6 @@ export class RelationCondition {
 
     allowed(condition: Condition): boolean {
         return this.ranges.every((x) => {
-            /*if (!x.range) {
-              console.log("range is undefined!", condition);
-            }*/
             return condition.matchRelation(x.range, {
                 id: x.cbdEntry,
                 store: this.store,
@@ -82,20 +78,20 @@ export class RelationCondition {
         const ty =
             getObjects(this.store, relationId, RDF.terms.type, null)[0] ||
             TREE.Relation;
+
         const path = getObjects(
             this.store,
             relationId,
             TREE.terms.path,
             null,
         )[0];
+
         const value = getObjects(
             this.store,
             relationId,
             TREE.terms.value,
             null,
         )[0];
-
-        //console.log("Add relation", { ty, path, value });
 
         let range = this.ranges.find((range) =>
             cbdEquals(

--- a/lib/pageFetcher.ts
+++ b/lib/pageFetcher.ts
@@ -1,6 +1,6 @@
 import { RdfDereferencer } from "rdf-dereference";
 import { Notifier } from "./utils";
-import { extractRelations, Relation } from "./page";
+import { extractRelations, Relation, Relations } from "./page";
 import { SimpleRelation } from "./relation";
 import { RdfStore } from "rdf-stores";
 import { DataFactory } from "rdf-data-factory";
@@ -53,7 +53,7 @@ export interface Helper {
 }
 
 export type FetchEvent = {
-    relationFound: { from: Node; target: Relation };
+    relationFound: { from: Node; target: Relations };
     pageFetched: FetchedPage;
     scheduleFetch: Node;
     error: unknown;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,6 @@ import { RDF, SHACL, TREE } from "@treecg/types";
 import { Member } from "./page";
 import { LDESInfo } from "./client";
 import { pred } from "rdf-lens";
-import { readFile } from "fs/promises";
 import {
     AndCondition,
     Condition,
@@ -614,19 +613,28 @@ export async function processConditionFile(
     conditionFile?: string,
 ): Promise<Condition> {
     let condition: Condition = empty_condition();
+
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    let fs: any;
+    if (typeof require === "undefined") {
+        import("fs/promises").then((mod) => (fs = mod));
+    } else {
+        /* eslint-disable  @typescript-eslint/no-require-imports */
+        fs = require("fs/promises");
+    }
+
     if (conditionFile) {
         try {
             condition = parse_condition(
-                await readFile(conditionFile, { encoding: "utf8" }),
+                await fs.readFile(conditionFile, { encoding: "utf8" }),
                 conditionFile,
             );
         } catch (ex) {
             console.error(`Failed to read condition file: ${conditionFile}`);
             throw ex;
         }
-        console.log("Found me some condition", !!condition);
-        console.log(condition.toString());
     }
+
     return condition;
 }
 

--- a/lib/utils/logUtil.ts
+++ b/lib/utils/logUtil.ts
@@ -3,11 +3,15 @@ import winston, { format, Logger } from "winston";
 const PROCESSOR_NAME = "ldes-client";
 
 const consoleTransport = new winston.transports.Console();
-consoleTransport.level =
-    process.env.LOG_LEVEL ||
-    (process.env.DEBUG?.includes(PROCESSOR_NAME) || process.env.DEBUG === "*"
-        ? "debug"
-        : "info");
+
+if (typeof process !== "undefined") {
+    consoleTransport.level =
+        process.env.LOG_LEVEL ||
+        (process.env.DEBUG?.includes(PROCESSOR_NAME) ||
+        process.env.DEBUG === "*"
+            ? "debug"
+            : "info");
+}
 
 const classLoggers = new WeakMap<Constructor, Logger>();
 const stringLoggers = new Map<string, Logger>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ldes-client",
-  "version": "0.0.10-alpha.14",
+  "version": "0.0.10-alpha.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ldes-client",
-      "version": "0.0.10-alpha.14",
+      "version": "0.0.10-alpha.15",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.6",

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -75,7 +75,9 @@ export class Fragment<T> {
         }
 
         for (const { id, member } of this.members) {
-            out.push(...new Parser().parse(`<${ldesId}> <${TREE.member}> <${id}>.`));
+            out.push(
+                ...new Parser().parse(`<${ldesId}> <${TREE.member}> <${id}>.`),
+            );
             out.push(...memberToQuads(id, member));
         }
 
@@ -167,7 +169,9 @@ export class Tree<T> {
                 await new Promise((res) => setTimeout(res, fragment.delay));
             }
             try {
-                quads.push(...fragment.toQuads(BASE + this.root(), this.memberToQuads));
+                quads.push(
+                    ...fragment.toQuads(BASE + this.root(), this.memberToQuads),
+                );
 
                 const respText = new Writer().quadsToString(quads);
 
@@ -177,6 +181,7 @@ export class Tree<T> {
 
                 return resp;
             } catch (ex) {
+                console.error(ex);
                 const resp = new Response("I'm too loaded yo", { status: 429 });
                 return resp;
             }


### PR DESCRIPTION
Problem:
The ordered strategy only took the first relation to some page into account, ignoring the others.
The LDES Solid Server first writes the GreaterThenOrEqualTo relations followed by the LessThen relations, allowing for 'ascending' ordering, but not for 'descending' ordering.

Fix:
Take into account all relations to a particular node during the extractRelations function from page.

Other fixes: (related to web environment)
* LogUtils: check if process is defined before touching the env.
* Dynamically load `fs/promises` when required.