### PR TITLE
Use retryConfig.base to calculate wait time between retries

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -494,7 +494,7 @@ export function retry_fetch(
 
     const retry: typeof fetch = async (input, init) => {
         let tryCount = 0;
-        let retryTime = config.maxRetries;
+        let retryTime = config.base;
         while (config.maxRetries == 0 || tryCount < config.maxRetries) {
             const resp = await fetch_f(input, init);
             if (!resp.ok) {


### PR DESCRIPTION
At the moment `retryConfig.base` is not taken into account. Retries of a failing request happen immediately one after another.

Inline documentation hints the intention was to increase (double) the wait time between retries. That's what this fix does.